### PR TITLE
feat(versions): limit versions on manager

### DIFF
--- a/app/src/main/java/app/revenge/manager/utils/VersionUtils.kt
+++ b/app/src/main/java/app/revenge/manager/utils/VersionUtils.kt
@@ -32,11 +32,23 @@ data class DiscordVersion(
             val codeReversed = toCharArray().reversed().joinToString("")
             val typeInt = codeReversed[2].toString().toInt()
             val type = Type.values().getOrNull(typeInt) ?: return@with null
-            DiscordVersion(
-                codeReversed.slice(3..codeReversed.lastIndex).reversed().toInt(),
-                codeReversed.substring(0, 2).reversed().toInt(),
-                type
-            )
+            // maintain version below 287
+            System.out.println("VERSIONNN" + toInt())
+            if (287 < toInt() / 1000)
+                when (typeInt) {
+                    0 -> fromVersionCode("287013") //latest stable version
+                    1 -> fromVersionCode("286109") //latest beta version
+                    2 -> fromVersionCode("287203") //latest alpha version
+                    else -> {
+                        fromVersionCode(string)
+                    }
+                }
+            else
+                DiscordVersion(
+                    codeReversed.slice(3..codeReversed.lastIndex).reversed().toInt(),
+                    codeReversed.substring(0, 2).reversed().toInt(),
+                    type
+                )
         }
 
     }

--- a/app/src/main/java/app/revenge/manager/utils/VersionUtils.kt
+++ b/app/src/main/java/app/revenge/manager/utils/VersionUtils.kt
@@ -33,7 +33,6 @@ data class DiscordVersion(
             val typeInt = codeReversed[2].toString().toInt()
             val type = Type.values().getOrNull(typeInt) ?: return@with null
             // maintain version below 287
-            System.out.println("VERSIONNN" + toInt())
             if (287 < toInt() / 1000)
                 when (typeInt) {
                     0 -> fromVersionCode("287013") //latest stable version


### PR DESCRIPTION
As we already know, revenge is broken on versions newer than 288 (https://discord.com/channels/1205207689832038522/1205211627629191288/1390020789561983046), so this patch limits the manager on the latest working version for all three channels.