### PR TITLE
fix(InstallStep/Shizuku): Installation method fallback

### DIFF
--- a/app/src/main/java/app/revenge/manager/installer/step/installing/InstallStep.kt
+++ b/app/src/main/java/app/revenge/manager/installer/step/installing/InstallStep.kt
@@ -14,6 +14,8 @@ import app.revenge.manager.installer.step.StepRunner
 import app.revenge.manager.utils.isMiui
 import app.revenge.manager.utils.showToast
 import org.koin.core.component.inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -42,7 +44,9 @@ class InstallStep(
 
         val installMethod = if (preferences.installMethod == InstallMethod.SHIZUKU && !ShizukuPermissions.waitShizukuPermissions()) {
             // Temporarily use DEFAULT if SHIZUKU permissions are not granted
-            context.showToast(R.string.msg_shizuku_denied)
+            withContext(Dispatchers.Main) {
+                context.applicationContext.showToast(R.string.msg_shizuku_denied)
+            }
             InstallMethod.DEFAULT
         } else {
             preferences.installMethod


### PR DESCRIPTION
After helping for a while on the server, I have noticed this issue. If the user sets Shizuku as the installation method and it becomes later unavailable, the code is set to throw a Toast, then fall back to session installer.

Regardless of this expected behavior, the installation will fail as the Toast does not get the right context to be displayed (it has to be thrown on the main thread).

This change aims to fix this error.